### PR TITLE
Add unit tests for numberParser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,7 +1962,6 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -4732,7 +4731,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6944,7 +6942,6 @@
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
       "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
@@ -7063,7 +7060,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/utils/__tests__/numberParser.test.ts
+++ b/src/utils/__tests__/numberParser.test.ts
@@ -1,0 +1,74 @@
+import { parseYouTubeNumber } from '../numberParser';
+
+describe('parseYouTubeNumber', () => {
+  test('should return 0 for null input', () => {
+    expect(parseYouTubeNumber(null)).toBe(0);
+  });
+
+  test('should return 0 for undefined input', () => {
+    expect(parseYouTubeNumber(undefined)).toBe(0);
+  });
+
+  test('should return 0 for an empty string input', () => {
+    expect(parseYouTubeNumber('')).toBe(0);
+  });
+
+  test('should parse a valid positive integer string', () => {
+    expect(parseYouTubeNumber('123')).toBe(123);
+  });
+
+  test('should parse a valid negative integer string', () => {
+    expect(parseYouTubeNumber('-456')).toBe(-456);
+  });
+
+  test('should parse "0"', () => {
+    expect(parseYouTubeNumber('0')).toBe(0);
+  });
+
+  test('should return 0 for a non-numeric string', () => {
+    expect(parseYouTubeNumber('abc')).toBe(0);
+  });
+
+  test('should handle strings with leading/trailing spaces', () => {
+    expect(parseYouTubeNumber(' 789 ')).toBe(789);
+  });
+
+  test('should handle strings that are partially numeric followed by non-numeric characters', () => {
+    expect(parseYouTubeNumber('123xyz')).toBe(123); // parseInt behavior
+  });
+
+  test('should handle strings representing floating-point numbers by truncating to integer', () => {
+    expect(parseYouTubeNumber('10.99')).toBe(10); // parseInt behavior
+  });
+
+  test('should handle already numeric input (though type is string | undefined | null)', () => {
+    // This case tests if String(value) works as expected for numbers if they were passed.
+    // However, the function signature expects string, undefined or null.
+    // Consider if this test is essential or if type enforcement makes it redundant.
+    // For now, assuming it's a string representation of a number.
+    expect(parseYouTubeNumber('777')).toBe(777);
+  });
+
+  test('should return 0 for string "NaN" as parseInt("NaN") is NaN', () => {
+    expect(parseYouTubeNumber('NaN')).toBe(0);
+  });
+
+  test('should return 0 for string "Infinity" as parseInt("Infinity") is NaN in some JS engines or a specific value', () => {
+    // parseInt behavior for "Infinity" can vary or be NaN.
+    // Given our function returns 0 for NaN, this should be 0.
+    expect(parseYouTubeNumber('Infinity')).toBe(0);
+  });
+
+   test('should return 0 for string "-Infinity"', () => {
+    expect(parseYouTubeNumber('-Infinity')).toBe(0);
+  });
+
+  test('should handle very large numbers as strings if they don_t exceed JS limits for parseInt', () => {
+    expect(parseYouTubeNumber('9007199254740990')).toBe(9007199254740990);
+    // Max safe integer is 9007199254740991. parseInt can handle it.
+  });
+
+  test('should parse a string with only spaces as 0, as parseInt(" ") is NaN', () => {
+    expect(parseYouTubeNumber('   ')).toBe(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "isolatedModules": true,
     "skipLibCheck": true,
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
This commit introduces a Jest test suite for the `parseYouTubeNumber` utility function. It includes 16 test cases covering various scenarios, including null, undefined, empty, valid numeric, and invalid string inputs, ensuring the function behaves as expected.

The `tsconfig.json` was also updated with `"isolatedModules": true` to address a `ts-jest` warning encountered during testing setup.