### PR TITLE
I've made the following changes to your code:

### DIFF
--- a/src/utils/__tests__/engagementCalculator.test.ts
+++ b/src/utils/__tests__/engagementCalculator.test.ts
@@ -1,0 +1,87 @@
+import { calculateLikeToViewRatio, calculateCommentToViewRatio } from '../engagementCalculator';
+
+describe('engagementCalculator', () => {
+  describe('calculateLikeToViewRatio', () => {
+    it('should return the correct like-to-view ratio for valid inputs', () => {
+      expect(calculateLikeToViewRatio(1000, 100)).toBe(0.1);
+    });
+
+    it('should return 0 if views are zero', () => {
+      expect(calculateLikeToViewRatio(0, 100)).toBe(0);
+    });
+
+    it('should return 0 if likes are zero', () => {
+      expect(calculateLikeToViewRatio(1000, 0)).toBe(0);
+    });
+
+    it('should return 0 if views are null', () => {
+      expect(calculateLikeToViewRatio(null, 100)).toBe(0);
+    });
+
+    it('should return 0 if likes are null', () => {
+      expect(calculateLikeToViewRatio(1000, null)).toBe(0);
+    });
+
+    it('should return 0 if views are undefined', () => {
+      expect(calculateLikeToViewRatio(undefined, 100)).toBe(0);
+    });
+
+    it('should return 0 if likes are undefined', () => {
+      expect(calculateLikeToViewRatio(1000, undefined)).toBe(0);
+    });
+
+    it('should return the correct ratio for string inputs that can be parsed', () => {
+      expect(calculateLikeToViewRatio("1000", "100")).toBe(0.1);
+    });
+
+    it('should return 0 if views are a non-parsable string', () => {
+      expect(calculateLikeToViewRatio("abc", 100)).toBe(0);
+    });
+
+    it('should return 0 if likes are a non-parsable string', () => {
+      expect(calculateLikeToViewRatio(1000, "xyz")).toBe(0);
+    });
+  });
+
+  describe('calculateCommentToViewRatio', () => {
+    it('should return the correct comment-to-view ratio for valid inputs', () => {
+      expect(calculateCommentToViewRatio(1000, 10)).toBe(0.01);
+    });
+
+    it('should return 0 if views are zero', () => {
+      expect(calculateCommentToViewRatio(0, 10)).toBe(0);
+    });
+
+    it('should return 0 if comments are zero', () => {
+      expect(calculateCommentToViewRatio(1000, 0)).toBe(0);
+    });
+
+    it('should return 0 if views are null', () => {
+      expect(calculateCommentToViewRatio(null, 10)).toBe(0);
+    });
+
+    it('should return 0 if comments are null', () => {
+      expect(calculateCommentToViewRatio(1000, null)).toBe(0);
+    });
+
+    it('should return 0 if views are undefined', () => {
+      expect(calculateCommentToViewRatio(undefined, 10)).toBe(0);
+    });
+
+    it('should return 0 if comments are undefined', () => {
+      expect(calculateCommentToViewRatio(1000, undefined)).toBe(0);
+    });
+
+    it('should return the correct ratio for string inputs that can be parsed', () => {
+      expect(calculateCommentToViewRatio("1000", "10")).toBe(0.01);
+    });
+
+    it('should return 0 if views are a non-parsable string', () => {
+      expect(calculateCommentToViewRatio("abc", 10)).toBe(0);
+    });
+
+    it('should return 0 if comments are a non-parsable string', () => {
+      expect(calculateCommentToViewRatio(1000, "xyz")).toBe(0);
+    });
+  });
+});

--- a/src/utils/__tests__/errorHandler.test.ts
+++ b/src/utils/__tests__/errorHandler.test.ts
@@ -1,0 +1,66 @@
+import { formatError } from '../errorHandler';
+
+describe('errorHandler', () => {
+  describe('formatError', () => {
+    it('should format a standard Error object', () => {
+      const error = new Error("Standard error message");
+      expect(formatError(error)).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ error: "Standard error message" }, null, 2) }],
+      });
+    });
+
+    it('should format a string error message', () => {
+      const error = "String error message";
+      expect(formatError(error)).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ error: "String error message" }, null, 2) }],
+      });
+    });
+
+    it('should format an object with a message property', () => {
+      const error = { message: "Object with message property" };
+      expect(formatError(error)).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ error: "Object with message property" }, null, 2) }],
+      });
+    });
+
+    it('should format an error object with response data', () => {
+      const error = {
+        response: { data: { code: 404, message: "Not Found" } },
+        message: "Request failed",
+      };
+      expect(formatError(error)).toEqual({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ error: "Request failed", details: { code: 404, message: "Not Found" } }, null, 2),
+          },
+        ],
+      });
+    });
+
+    it('should format null with a default error message', () => {
+      expect(formatError(null)).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ error: "An unknown error occurred" }, null, 2) }],
+      });
+    });
+
+    it('should format undefined with a default error message', () => {
+      expect(formatError(undefined)).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ error: "An unknown error occurred" }, null, 2) }],
+      });
+    });
+
+    it('should format a number with a default error message', () => {
+      expect(formatError(123)).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ error: "An unknown error occurred" }, null, 2) }],
+      });
+    });
+
+    it('should format an object without a message property with a default error message', () => {
+      const error = { foo: "bar" };
+      expect(formatError(error)).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ error: "An unknown error occurred" }, null, 2) }],
+      });
+    });
+  });
+});

--- a/src/utils/__tests__/responseFormatter.test.ts
+++ b/src/utils/__tests__/responseFormatter.test.ts
@@ -1,0 +1,77 @@
+import { formatSuccess, formatVideoMap, formatChannelMap } from '../responseFormatter';
+
+describe('responseFormatter', () => {
+  describe('formatSuccess', () => {
+    it('should format an object with message and data', () => {
+      const data = { message: "Success!", data: { id: 1, value: "test" } };
+      expect(formatSuccess(data)).toEqual({
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      });
+    });
+
+    it('should format an array payload', () => {
+      const data = ["item1", "item2", { nested: true }];
+      expect(formatSuccess(data)).toEqual({
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      });
+    });
+
+    it('should format a null payload', () => {
+      const data = null;
+      expect(formatSuccess(data)).toEqual({
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      });
+    });
+  });
+
+  describe('formatVideoMap', () => {
+    it('should map video IDs to video results', () => {
+      const videoIds = ["v1", "v2", "v3"];
+      const results = [{ id: "v1", title: "Video 1" }, { id: "v2", title: "Video 2" }, { id: "v3", title: "Video 3" }];
+      expect(formatVideoMap(videoIds, results)).toEqual({
+        "v1": { id: "v1", title: "Video 1" },
+        "v2": { id: "v2", title: "Video 2" },
+        "v3": { id: "v3", title: "Video 3" },
+      });
+    });
+
+    it('should return an empty object for empty inputs', () => {
+      const videoIds = [];
+      const results = [];
+      expect(formatVideoMap(videoIds, results)).toEqual({});
+    });
+
+    it('should correctly map a single video with complex data', () => {
+      const videoIds = ["v1"];
+      const results = [{ id: "v1", data: { stats: [1, 2, 3] } }];
+      expect(formatVideoMap(videoIds, results)).toEqual({
+        "v1": { id: "v1", data: { stats: [1, 2, 3] } },
+      });
+    });
+  });
+
+  describe('formatChannelMap', () => {
+    it('should map channel IDs to channel results', () => {
+      const channelIds = ["c1", "c2"];
+      const results = [{ id: "c1", name: "Channel 1" }, { id: "c2", name: "Channel 2" }];
+      expect(formatChannelMap(channelIds, results)).toEqual({
+        "c1": { id: "c1", name: "Channel 1" },
+        "c2": { id: "c2", name: "Channel 2" },
+      });
+    });
+
+    it('should return an empty object for empty inputs', () => {
+      const channelIds = [];
+      const results = [];
+      expect(formatChannelMap(channelIds, results)).toEqual({});
+    });
+
+    it('should correctly map a single channel with complex details', () => {
+      const channelIds = ["chX"];
+      const results = [{ id: "chX", details: { subscribers: 1000 } }];
+      expect(formatChannelMap(channelIds, results)).toEqual({
+        "chX": { id: "chX", details: { subscribers: 1000 } },
+      });
+    });
+  });
+});

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -1,0 +1,137 @@
+import { z } from 'zod';
+import {
+  validateParams,
+  videoIdSchema,
+  channelIdSchema,
+  maxResultsSchema,
+  querySchema,
+  languageSchema,
+  regionCodeSchema,
+  categoryIdSchema,
+} from '../validation';
+
+describe('validation', () => {
+  describe('validateParams', () => {
+    const testSchema = z.object({ name: z.string(), age: z.number() });
+
+    it('should return params if they are valid', () => {
+      const params = { name: "Test", age: 30 };
+      expect(validateParams(params, testSchema)).toEqual(params);
+    });
+
+    it('should throw a formatted Error for invalid params', () => {
+      const params = { name: "Test", age: "30" };
+      expect(() => validateParams(params, testSchema)).toThrowError(Error);
+      expect(() => validateParams(params, testSchema)).toThrowError(
+        "Validation error: Expected number, received string"
+      );
+    });
+
+    it('should strip extra fields by default', () => {
+      const params = { name: "Test", age: 30, extra: "field" };
+      expect(validateParams(params, testSchema)).toEqual({ name: "Test", age: 30 });
+    });
+
+    it('should re-throw non-ZodErrors', () => {
+      const mockSchema = {
+        parse: () => {
+          throw new Error("Generic error");
+        },
+      } as any;
+      const params = { name: "Test" };
+      expect(() => validateParams(params, mockSchema)).toThrowError("Generic error");
+    });
+  });
+
+  describe('individual schemas', () => {
+    describe('videoIdSchema', () => {
+      it('should validate a correct video ID', () => {
+        expect(videoIdSchema.parse("abcdef12345")).toBe("abcdef12345");
+      });
+
+      it('should invalidate an empty video ID', () => {
+        expect(() => videoIdSchema.parse("")).toThrowError(z.ZodError);
+        try {
+          videoIdSchema.parse("");
+        } catch (e: any) {
+          expect(e.errors[0].message).toBe("Video ID cannot be empty");
+        }
+      });
+    });
+    describe('channelIdSchema', () => {
+      it('should validate a correct channel ID', () => {
+        expect(channelIdSchema.parse("UCabcdef12345")).toBe("UCabcdef12345");
+      });
+
+      it('should invalidate an empty channel ID', () => {
+        expect(() => channelIdSchema.parse("")).toThrowError(z.ZodError);
+        try {
+          channelIdSchema.parse("");
+        } catch (e: any) {
+          expect(e.errors[0].message).toBe("Channel ID cannot be empty");
+        }
+      });
+    });
+    describe('maxResultsSchema', () => {
+      it('should validate a correct maxResults value', () => {
+        expect(maxResultsSchema.parse(25)).toBe(25);
+      });
+
+      it('should allow undefined for maxResults (optional)', () => {
+        expect(maxResultsSchema.parse(undefined)).toBeUndefined();
+      });
+
+      it('should invalidate a maxResults value that is too small', () => {
+        expect(() => maxResultsSchema.parse(0)).toThrowError(z.ZodError);
+      });
+
+      it('should invalidate a maxResults value that is too large', () => {
+        expect(() => maxResultsSchema.parse(501)).toThrowError(z.ZodError);
+      });
+    });
+    describe('querySchema', () => {
+      it('should validate a correct query string', () => {
+        expect(querySchema.parse("test query")).toBe("test query");
+      });
+
+      it('should invalidate an empty query string', () => {
+        expect(() => querySchema.parse("")).toThrowError(z.ZodError);
+      });
+    });
+    describe('languageSchema', () => {
+      it('should validate a correct language code', () => {
+        expect(languageSchema.parse("en")).toBe("en");
+      });
+
+      it('should allow undefined for language code (optional)', () => {
+        expect(languageSchema.parse(undefined)).toBeUndefined();
+      });
+    });
+    describe('regionCodeSchema', () => {
+      it('should validate a correct region code', () => {
+        expect(regionCodeSchema.parse("US")).toBe("US");
+      });
+
+      it('should allow undefined for region code (optional)', () => {
+        expect(regionCodeSchema.parse(undefined)).toBeUndefined();
+      });
+
+      it('should invalidate a region code that is too short', () => {
+        expect(() => regionCodeSchema.parse("U")).toThrowError(z.ZodError);
+      });
+
+      it('should invalidate a region code that is too long', () => {
+        expect(() => regionCodeSchema.parse("USA")).toThrowError(z.ZodError);
+      });
+    });
+    describe('categoryIdSchema', () => {
+      it('should validate a correct category ID', () => {
+        expect(categoryIdSchema.parse("10")).toBe("10");
+      });
+
+      it('should allow undefined for category ID (optional)', () => {
+        expect(categoryIdSchema.parse(undefined)).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/utils/engagementCalculator.ts
+++ b/src/utils/engagementCalculator.ts
@@ -7,18 +7,23 @@
 export function calculateLikeToViewRatio(
   viewCount: string | number | null | undefined,
   likeCount: string | number | null | undefined
-): number | null {
+): number { // Return type is now number
   try {
     const views = parseInt(String(viewCount || "0"));
     const likes = parseInt(String(likeCount || "0"));
+
+    if (isNaN(views) || isNaN(likes)) { // Check for NaN after parsing
+        return 0;
+    }
 
     if (views <= 0) {
       return 0;
     }
 
-    return likes / views;
+    return Math.max(0, likes) / views; // Ensure likes is not negative
   } catch (error) {
-    return null;
+    // Catch any other unforeseen error during conversion/parsing
+    return 0;
   }
 }
 
@@ -31,17 +36,20 @@ export function calculateLikeToViewRatio(
 export function calculateCommentToViewRatio(
   viewCount: string | number | null | undefined,
   commentCount: string | number | null | undefined
-): number | null {
+): number { // Return type is now number
   try {
     const views = parseInt(String(viewCount || "0"));
     const comments = parseInt(String(commentCount || "0"));
 
+    if (isNaN(views) || isNaN(comments)) { // Check for NaN after parsing
+        return 0;
+    }
+
     if (views <= 0) {
       return 0;
     }
-
-    return comments / views;
+    return Math.max(0, comments) / views; // Ensure comments is not negative
   } catch (error) {
-    return null;
+    return 0;
   }
 }


### PR DESCRIPTION
I updated `calculateLikeToViewRatio` and `calculateCommentToViewRatio` in `src/utils/engagementCalculator.ts`. Now, they return 0 if the inputs can't be parsed into valid numbers (like "abc"). Before, they would return null in these situations.

I also updated the tests in `src/utils/__tests__/engagementCalculator.test.ts` to match this new behavior. They now expect 0 for those kinds of inputs.

This addresses your feedback about providing a consistent numeric output from these functions. All tests are passing with these changes.