### PR TITLE
feat: add unit tests for database service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "jest-junit": "^16.0.0",
         "prettier": "^3.5.3",
         "rimraf": "^6.0.1",
-        "ts-jest": "^29.3.4",
+        "ts-jest": "^29.4.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.33.1"
       },
@@ -7228,15 +7228,14 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
-      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
+      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
       "dev": true,
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
@@ -7252,10 +7251,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -7272,6 +7272,9 @@
           "optional": true
         },
         "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jest-junit": "^16.0.0",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
-    "ts-jest": "^29.3.4",
+    "ts-jest": "^29.4.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1"
   },

--- a/src/services/__tests__/database.service.test.ts
+++ b/src/services/__tests__/database.service.test.ts
@@ -1,0 +1,95 @@
+import {
+  connectToDatabase,
+  disconnectFromDatabase,
+  getDb,
+} from "../database.service";
+import { MongoClient, Db } from "mongodb";
+
+// Define mocks for MongoClient methods before the jest.mock call
+const mockConnect = jest.fn().mockResolvedValue(undefined);
+const mockDbMethod = jest.fn().mockReturnValue({} as Db); // Renamed to avoid conflict with Db type
+const mockClose = jest.fn().mockResolvedValue(undefined);
+
+// Mock MongoClient
+jest.mock("mongodb", () => {
+  const originalModule = jest.requireActual("mongodb"); // Import and retain original parts
+  return {
+    ...originalModule, // Spread original module exports
+    MongoClient: jest.fn().mockImplementation(() => ({
+      connect: mockConnect,
+      db: mockDbMethod,
+      close: mockClose,
+    })),
+  };
+});
+
+describe("DatabaseService Connection Lifecycle", () => {
+  beforeEach(() => {
+    // Reset mocks before each test to ensure test isolation
+    mockConnect.mockClear();
+    mockDbMethod.mockClear();
+    mockClose.mockClear();
+    // Set a dummy connection string for tests that expect it to be present
+    process.env.MDB_MCP_CONNECTION_STRING = "mongodb://dummy-connection-string";
+  });
+
+  it("should connect, get DB, and disconnect successfully", async () => {
+    // 1. Connect to Database
+    await connectToDatabase();
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    // 2. Get Db instance
+    const dbInstance = getDb();
+    expect(mockDbMethod).toHaveBeenCalledTimes(1);
+    // Ensure the correct database name is passed to client.db() if applicable
+    // For now, checking if it's called and returns the mock is sufficient
+    expect(dbInstance).toEqual({}); // It returns the mocked Db object
+
+    // 3. Disconnect from Database
+    await disconnectFromDatabase();
+    expect(mockClose).toHaveBeenCalledTimes(1);
+
+    // 4. Verify Db is null or getDb throws error
+    try {
+      getDb();
+      // If getDb() does not throw, this line will fail the test
+      expect(true).toBe(false);
+    } catch (error: any) {
+      expect(error.message).toBe(
+        "MongoDB connection not established. Call connectToDatabase() first."
+      );
+    }
+  });
+
+  it("should throw an error if MDB_MCP_CONNECTION_STRING is not set", async () => {
+    const originalConnectionString = process.env.MDB_MCP_CONNECTION_STRING;
+    delete process.env.MDB_MCP_CONNECTION_STRING; // Or set to undefined
+
+    try {
+      await connectToDatabase();
+      // If connectToDatabase does not throw, this line will fail the test
+      expect(true).toBe(false);
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe(
+        "Failed to connect to MongoDB: MDB_MCP_CONNECTION_STRING environment variable is required"
+      );
+    } finally {
+      // Restore the original environment variable
+      process.env.MDB_MCP_CONNECTION_STRING = originalConnectionString;
+    }
+  });
+
+  it("should throw an error when getDb is called before connectToDatabase", () => {
+    try {
+      getDb();
+      // If getDb() does not throw, this line will fail the test
+      expect(true).toBe(false);
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe(
+        "MongoDB connection not established. Call connectToDatabase() first."
+      );
+    }
+  });
+});


### PR DESCRIPTION
Added unit tests for the `database.service.ts` to cover the following cases:

- Successful connection and disconnection lifecycle:
    - Mocks `MongoClient`.
    - Calls `connectToDatabase` and asserts that `mongoClient.connect` was called.
    - Calls `getDb` and verifies it returns the mock database instance.
    - Calls `disconnectFromDatabase` and asserts that `mongoClient.close` was called and the internal `db` variable is set to `null`.
- Failure to connect due to a missing environment variable:
    - Sets `process.env.MDB_MCP_CONNECTION_STRING` to `undefined`.
    - Calls `connectToDatabase` and asserts that it throws a specific, informative error about the missing variable.
- Attempting to get a DB instance before connecting:
    - Ensures no connection has been established.
    - Calls `getDb` directly and asserts that it throws an error indicating that `connectToDatabase()` must be called first.

All tests pass, and the code has been linted and formatted.