### PR TITLE
I've refactored the organization of unit tests for the YoutubeService…

### DIFF
--- a/src/services/__tests__/youtube/batchFetchChannelStatistics.test.ts
+++ b/src/services/__tests__/youtube/batchFetchChannelStatistics.test.ts
@@ -1,0 +1,198 @@
+import { YoutubeService } from "../../youtube.service"; // Adjusted path
+import { CacheService } from "../../cache.service"; // Adjusted path
+
+// Mock googleapis
+jest.mock("googleapis", () => {
+  const mockChannelsListFn = jest.fn();
+  const mockYoutubeInstance = {
+    videos: { list: jest.fn() },
+    channels: { list: mockChannelsListFn },
+    search: { list: jest.fn() },
+  };
+  return {
+    google: {
+      youtube: jest.fn(() => mockYoutubeInstance),
+    },
+    __mockVideosList: jest.fn(),
+    __mockChannelsList: mockChannelsListFn,
+    __mockSearchList: jest.fn(),
+  };
+});
+
+// Mock CacheService
+jest.mock("../../cache.service", () => {
+  // Adjusted path
+  const mockCacheInstanceInternal = {
+    getOrSet: jest.fn(),
+    createOperationKey: jest.fn(
+      (operationName, params) => `${operationName}-${JSON.stringify(params)}`
+    ),
+  };
+  return {
+    CacheService: jest.fn(() => mockCacheInstanceInternal),
+  };
+});
+
+// Import the specific mocks for googleapis
+const { __mockChannelsList: mockChannelsList } = jest.requireMock("googleapis");
+
+// Import the CacheService factory
+const { CacheService: MockedCacheService } = jest.requireMock(
+  "../../cache.service"
+); // Adjusted path
+
+describe("YoutubeService - batchFetchChannelStatistics", () => {
+  let youtubeService: YoutubeService;
+  let mockCacheServiceInstance: jest.Mocked<CacheService>;
+
+  beforeEach(() => {
+    process.env.YOUTUBE_API_KEY = "test_api_key";
+
+    mockChannelsList.mockReset();
+
+    mockCacheServiceInstance =
+      new MockedCacheService() as jest.Mocked<CacheService>;
+    mockCacheServiceInstance.getOrSet.mockImplementation(
+      (cacheKey, operation) => operation()
+    );
+
+    youtubeService = new YoutubeService(mockCacheServiceInstance);
+    youtubeService.resetApiCreditsUsed();
+  });
+
+  afterEach(() => {
+    delete process.env.YOUTUBE_API_KEY;
+  });
+
+  // Copied from the original youtube.service.test.ts
+  it("should return an empty map if no channel IDs are provided", async () => {
+    const result = await youtubeService.batchFetchChannelStatistics([]);
+    expect(result).toEqual(new Map());
+    expect(mockChannelsList).not.toHaveBeenCalled();
+    expect(youtubeService.getApiCreditsUsed()).toBe(0);
+  });
+
+  it("should fetch statistics for a single channel ID", async () => {
+    const mockChannelData = {
+      id: "channel1",
+      snippet: { title: "Channel 1" },
+      statistics: { viewCount: "100" },
+    };
+    mockChannelsList.mockResolvedValueOnce({
+      data: { items: [mockChannelData] },
+    });
+
+    const result = await youtubeService.batchFetchChannelStatistics([
+      "channel1",
+    ]);
+
+    expect(mockChannelsList).toHaveBeenCalledWith({
+      part: ["snippet", "statistics"],
+      id: ["channel1"],
+    });
+    expect(result.size).toBe(1);
+    expect(result.get("channel1")).toEqual(mockChannelData);
+    expect(youtubeService.getApiCreditsUsed()).toBe(1);
+  });
+
+  it("should fetch statistics for multiple channel IDs in a single batch", async () => {
+    const mockChannelData1 = {
+      id: "channel1",
+      snippet: { title: "Channel 1" },
+      statistics: { viewCount: "100" },
+    };
+    const mockChannelData2 = {
+      id: "channel2",
+      snippet: { title: "Channel 2" },
+      statistics: { viewCount: "200" },
+    };
+    mockChannelsList.mockResolvedValueOnce({
+      data: { items: [mockChannelData1, mockChannelData2] },
+    });
+
+    const result = await youtubeService.batchFetchChannelStatistics([
+      "channel1",
+      "channel2",
+    ]);
+
+    expect(mockChannelsList).toHaveBeenCalledWith({
+      part: ["snippet", "statistics"],
+      id: ["channel1", "channel2"],
+    });
+    expect(result.size).toBe(2);
+    expect(result.get("channel1")).toEqual(mockChannelData1);
+    expect(result.get("channel2")).toEqual(mockChannelData2);
+    expect(youtubeService.getApiCreditsUsed()).toBe(1);
+  });
+
+  it("should fetch statistics for multiple channel IDs in multiple batches", async () => {
+    const manyChannelIds = Array.from({ length: 51 }, (_, i) => `channel${i}`);
+    const firstBatchIds = manyChannelIds.slice(0, 50);
+    const secondBatchIds = manyChannelIds.slice(50);
+
+    const mockResponseItems1 = firstBatchIds.map((id) => ({
+      id,
+      snippet: { title: id },
+      statistics: {},
+    }));
+    const mockResponseItems2 = secondBatchIds.map((id) => ({
+      id,
+      snippet: { title: id },
+      statistics: {},
+    }));
+
+    mockChannelsList
+      .mockResolvedValueOnce({ data: { items: mockResponseItems1 } })
+      .mockResolvedValueOnce({ data: { items: mockResponseItems2 } });
+
+    const result =
+      await youtubeService.batchFetchChannelStatistics(manyChannelIds);
+
+    expect(mockChannelsList).toHaveBeenCalledTimes(2);
+    expect(mockChannelsList).toHaveBeenNthCalledWith(1, {
+      part: ["snippet", "statistics"],
+      id: firstBatchIds,
+    });
+    expect(mockChannelsList).toHaveBeenNthCalledWith(2, {
+      part: ["snippet", "statistics"],
+      id: secondBatchIds,
+    });
+    expect(result.size).toBe(51);
+    expect(result.get("channel0")).toEqual(mockResponseItems1[0]);
+    expect(result.get("channel50")).toEqual(mockResponseItems2[0]);
+    expect(youtubeService.getApiCreditsUsed()).toBe(2);
+  });
+
+  it("should handle cases where some channels are not found or API returns partial data", async () => {
+    const mockChannelData1 = {
+      id: "channel1",
+      snippet: { title: "Channel 1" },
+      statistics: { viewCount: "100" },
+    };
+    mockChannelsList.mockResolvedValueOnce({
+      data: { items: [mockChannelData1] },
+    });
+
+    const result = await youtubeService.batchFetchChannelStatistics([
+      "channel1",
+      "channel2",
+    ]);
+
+    expect(mockChannelsList).toHaveBeenCalledWith({
+      part: ["snippet", "statistics"],
+      id: ["channel1", "channel2"],
+    });
+    expect(result.size).toBe(1);
+    expect(result.get("channel1")).toEqual(mockChannelData1);
+    expect(result.has("channel2")).toBe(false);
+    expect(youtubeService.getApiCreditsUsed()).toBe(1);
+  });
+
+  it("should throw an error if the API call fails", async () => {
+    mockChannelsList.mockRejectedValueOnce(new Error("API Error"));
+    await expect(
+      youtubeService.batchFetchChannelStatistics(["channel1"])
+    ).rejects.toThrow("Failed to fetch channel statistics: API Error");
+    expect(youtubeService.getApiCreditsUsed()).toBe(1);
+  });
+});

--- a/src/services/__tests__/youtube/fetchChannelRecentTopVideos.test.ts
+++ b/src/services/__tests__/youtube/fetchChannelRecentTopVideos.test.ts
@@ -1,0 +1,227 @@
+import { YoutubeService } from "../../youtube.service"; // Adjusted path
+import { CacheService } from "../../cache.service"; // Adjusted path
+
+// Mock googleapis
+jest.mock("googleapis", () => {
+  const mockVideosListFn = jest.fn();
+  const mockSearchListFn = jest.fn();
+  const mockYoutubeInstance = {
+    videos: { list: mockVideosListFn },
+    channels: { list: jest.fn() },
+    search: { list: mockSearchListFn },
+  };
+  return {
+    google: {
+      youtube: jest.fn(() => mockYoutubeInstance),
+    },
+    __mockVideosList: mockVideosListFn,
+    __mockChannelsList: jest.fn(),
+    __mockSearchList: mockSearchListFn,
+  };
+});
+
+// Mock CacheService
+jest.mock("../../cache.service", () => {
+  // Adjusted path
+  const mockCacheInstanceInternal = {
+    getOrSet: jest.fn(),
+    createOperationKey: jest.fn(
+      (operationName, params) => `${operationName}-${JSON.stringify(params)}`
+    ),
+  };
+  return {
+    CacheService: jest.fn(() => mockCacheInstanceInternal),
+  };
+});
+
+// Import the specific mocks for googleapis
+const { __mockVideosList: mockVideosList, __mockSearchList: mockSearchList } =
+  jest.requireMock("googleapis");
+
+// Import the CacheService factory
+const { CacheService: MockedCacheService } = jest.requireMock(
+  "../../cache.service"
+); // Adjusted path
+
+describe("YoutubeService - fetchChannelRecentTopVideos", () => {
+  let youtubeService: YoutubeService;
+  let mockCacheServiceInstance: jest.Mocked<CacheService>;
+
+  beforeEach(() => {
+    process.env.YOUTUBE_API_KEY = "test_api_key";
+
+    mockVideosList.mockReset();
+    mockSearchList.mockReset();
+
+    mockCacheServiceInstance =
+      new MockedCacheService() as jest.Mocked<CacheService>;
+    mockCacheServiceInstance.getOrSet.mockImplementation(
+      (cacheKey, operation) => operation()
+    );
+
+    youtubeService = new YoutubeService(mockCacheServiceInstance);
+    youtubeService.resetApiCreditsUsed();
+  });
+
+  afterEach(() => {
+    delete process.env.YOUTUBE_API_KEY;
+  });
+
+  // Copied from the original youtube.service.test.ts
+  it("should fetch recent top videos for a channel", async () => {
+    const channelId = "channel1";
+    const publishedAfter = "2023-01-01T00:00:00Z";
+    const mockSearchItems = [
+      { id: { videoId: "video1" } },
+      { id: { videoId: "video2" } },
+    ];
+    const mockVideoItems = [
+      {
+        id: "video1",
+        statistics: { viewCount: "1000" },
+        contentDetails: { duration: "PT1M" },
+      },
+      {
+        id: "video2",
+        statistics: { viewCount: "2000" },
+        contentDetails: { duration: "PT2M" },
+      },
+    ];
+
+    mockSearchList.mockResolvedValueOnce({
+      data: { items: mockSearchItems, nextPageToken: undefined },
+    });
+    mockVideosList.mockResolvedValueOnce({
+      data: { items: mockVideoItems },
+    });
+
+    const result = await youtubeService.fetchChannelRecentTopVideos(
+      channelId,
+      publishedAfter
+    );
+
+    expect(mockSearchList).toHaveBeenCalledWith({
+      channelId: channelId,
+      part: ["snippet"],
+      order: "viewCount",
+      maxResults: 50,
+      publishedAfter: publishedAfter,
+      type: ["video"],
+      pageToken: undefined,
+    });
+    expect(mockVideosList).toHaveBeenCalledWith({
+      part: ["statistics", "contentDetails"],
+      id: ["video1", "video2"],
+    });
+    expect(result).toEqual(mockVideoItems);
+    expect(youtubeService.getApiCreditsUsed()).toBe(101);
+  });
+
+  it("should return an empty array if search returns no videos", async () => {
+    const channelId = "channel2";
+    const publishedAfter = "2023-01-01T00:00:00Z";
+    mockSearchList.mockResolvedValueOnce({ data: { items: [] } });
+
+    const result = await youtubeService.fetchChannelRecentTopVideos(
+      channelId,
+      publishedAfter
+    );
+
+    expect(mockSearchList).toHaveBeenCalledTimes(1);
+    expect(mockVideosList).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+    expect(youtubeService.getApiCreditsUsed()).toBe(100);
+  });
+
+  it("should return an empty array if video details fetch returns no items", async () => {
+    const channelId = "channel3";
+    const publishedAfter = "2023-01-01T00:00:00Z";
+    const mockSearchItems = [{ id: { videoId: "video3" } }];
+
+    mockSearchList.mockResolvedValueOnce({
+      data: { items: mockSearchItems },
+    });
+    mockVideosList.mockResolvedValueOnce({ data: { items: [] } });
+
+    const result = await youtubeService.fetchChannelRecentTopVideos(
+      channelId,
+      publishedAfter
+    );
+
+    expect(mockSearchList).toHaveBeenCalledTimes(1);
+    expect(mockVideosList).toHaveBeenCalledWith({
+      part: ["statistics", "contentDetails"],
+      id: ["video3"],
+    });
+    expect(result).toEqual([]);
+    expect(youtubeService.getApiCreditsUsed()).toBe(101);
+  });
+
+  it("should filter out undefined video IDs from search results before fetching video details", async () => {
+    const channelId = "channel4";
+    const publishedAfter = "2023-01-01T00:00:00Z";
+    const mockSearchItems = [
+      { id: { videoId: "video4" } },
+      { id: {} },
+      { id: { videoId: "video5" } },
+    ];
+    const mockVideoItems = [
+      {
+        id: "video4",
+        statistics: { viewCount: "100" },
+        contentDetails: { duration: "PT1M" },
+      },
+      {
+        id: "video5",
+        statistics: { viewCount: "200" },
+        contentDetails: { duration: "PT1M" },
+      },
+    ];
+
+    mockSearchList.mockResolvedValueOnce({
+      data: { items: mockSearchItems },
+    });
+    mockVideosList.mockResolvedValueOnce({
+      data: { items: mockVideoItems },
+    });
+
+    await youtubeService.fetchChannelRecentTopVideos(channelId, publishedAfter);
+
+    expect(mockVideosList).toHaveBeenCalledWith({
+      part: ["statistics", "contentDetails"],
+      id: ["video4", "video5"],
+    });
+    expect(youtubeService.getApiCreditsUsed()).toBe(101);
+  });
+
+  it("should throw an error if search.list API call fails", async () => {
+    const channelId = "channel5";
+    const publishedAfter = "2023-01-01T00:00:00Z";
+    mockSearchList.mockRejectedValueOnce(new Error("Search API Error"));
+
+    await expect(
+      youtubeService.fetchChannelRecentTopVideos(channelId, publishedAfter)
+    ).rejects.toThrow(
+      `Failed to fetch recent top videos for channel ${channelId}: Search API Error`
+    );
+    expect(youtubeService.getApiCreditsUsed()).toBe(100);
+  });
+
+  it("should throw an error if videos.list API call fails", async () => {
+    const channelId = "channel6";
+    const publishedAfter = "2023-01-01T00:00:00Z";
+    const mockSearchItems = [{ id: { videoId: "video6" } }];
+
+    mockSearchList.mockResolvedValueOnce({
+      data: { items: mockSearchItems },
+    });
+    mockVideosList.mockRejectedValueOnce(new Error("Videos API Error"));
+
+    await expect(
+      youtubeService.fetchChannelRecentTopVideos(channelId, publishedAfter)
+    ).rejects.toThrow(
+      `Failed to fetch recent top videos for channel ${channelId}: Videos API Error`
+    );
+    expect(youtubeService.getApiCreditsUsed()).toBe(101);
+  });
+});

--- a/src/services/__tests__/youtube/youtube.service.api_credits.test.ts
+++ b/src/services/__tests__/youtube/youtube.service.api_credits.test.ts
@@ -1,0 +1,95 @@
+import { YoutubeService } from "../../youtube.service"; // Adjusted path
+import { CacheService } from "../../cache.service"; // Adjusted path
+
+// Mock googleapis
+jest.mock("googleapis", () => {
+  const mockVideosListFn = jest.fn();
+  // We only need videos.list for API credit tests related to getVideo
+  const mockYoutubeInstance = {
+    videos: { list: mockVideosListFn },
+    channels: { list: jest.fn() }, // Keep other mocks available if YoutubeService constructor uses them
+    search: { list: jest.fn() },
+  };
+  return {
+    google: {
+      youtube: jest.fn(() => mockYoutubeInstance),
+    },
+    __mockVideosList: mockVideosListFn,
+    // Export other mocks even if not used by this specific suite, for consistency if YoutubeService init needs them
+    __mockChannelsList: jest.fn(),
+    __mockSearchList: jest.fn(),
+  };
+});
+
+// Mock CacheService
+jest.mock("../../cache.service", () => {
+  // Adjusted path
+  const mockCacheInstanceInternal = {
+    getOrSet: jest.fn(),
+    createOperationKey: jest.fn(
+      (operationName, params) => `${operationName}-${JSON.stringify(params)}`
+    ),
+  };
+  return {
+    CacheService: jest.fn(() => mockCacheInstanceInternal),
+  };
+});
+
+// Import the specific mocks for googleapis
+const { __mockVideosList: mockVideosList } = jest.requireMock("googleapis");
+
+// Import the CacheService factory
+const { CacheService: MockedCacheService } = jest.requireMock(
+  "../../cache.service"
+); // Adjusted path
+
+describe("YoutubeService - API Credit Usage", () => {
+  let youtubeService: YoutubeService;
+  let mockCacheServiceInstance: jest.Mocked<CacheService>;
+
+  beforeEach(() => {
+    process.env.YOUTUBE_API_KEY = "test_api_key";
+
+    mockVideosList.mockReset();
+
+    mockCacheServiceInstance =
+      new MockedCacheService() as jest.Mocked<CacheService>;
+    mockCacheServiceInstance.getOrSet.mockImplementation(
+      (cacheKey, operation) => operation()
+    );
+
+    youtubeService = new YoutubeService(mockCacheServiceInstance);
+    youtubeService.resetApiCreditsUsed();
+  });
+
+  afterEach(() => {
+    delete process.env.YOUTUBE_API_KEY;
+  });
+
+  // Tests for getApiCreditsUsed, resetApiCreditsUsed, and credit increment
+  it("should return 0 API credits used initially", () => {
+    expect(youtubeService.getApiCreditsUsed()).toBe(0);
+  });
+
+  it("should reset API credits used", async () => {
+    mockVideosList.mockResolvedValueOnce({
+      data: { items: [{ id: "videoId" }] },
+    });
+    await youtubeService.getVideo({ videoId: "videoId" });
+
+    youtubeService.resetApiCreditsUsed();
+    expect(youtubeService.getApiCreditsUsed()).toBe(0);
+  });
+
+  it("should increment API credits after an API call (getVideo)", async () => {
+    mockVideosList
+      .mockResolvedValueOnce({ data: { items: [{ id: "testVideo" }] } })
+      .mockResolvedValueOnce({ data: { items: [{ id: "testVideo2" }] } });
+
+    await youtubeService.getVideo({ videoId: "testVideo" });
+    expect(youtubeService.getApiCreditsUsed()).toBe(1); // Cost of videos.list is 1
+
+    await youtubeService.getVideo({ videoId: "testVideo2" });
+    expect(youtubeService.getApiCreditsUsed()).toBe(2); // Incremented
+  });
+});


### PR DESCRIPTION
… methods.

The tests that were previously in a single file (`src/services/__tests__/youtube.service.test.ts`) have now been split into separate, more granular files. Each new file is dedicated to a specific method or aspect of the YoutubeService.

Here are the new test files:
- src/services/__tests__/youtube/youtube.service.api_credits.test.ts: This contains tests for API credit tracking (getApiCreditsUsed, resetApiCreditsUsed, and increment logic).
- src/services/__tests__/youtube/batchFetchChannelStatistics.test.ts: This contains tests for the batchFetchChannelStatistics method.
- src/services/__tests__/youtube/fetchChannelRecentTopVideos.test.ts: This contains tests for the fetchChannelRecentTopVideos method.

The original combined test file (`src/services/__tests__/youtube.service.test.ts`) has been removed as its contents were fully migrated to these new files.

This new structure aligns better with the existing pattern in `src/services/__tests__/youtube/` where tests for specific functionalities are often in their own files.

All tests pass, the linter reports no new errors, and the code has been formatted with Prettier.