### PR TITLE
Fix: Remove unused ErrorResponse import

### DIFF
--- a/src/utils/__tests__/errorHandler.test.ts
+++ b/src/utils/__tests__/errorHandler.test.ts
@@ -1,4 +1,4 @@
-import { formatError, ErrorResponse } from "../errorHandler"; // Assuming ErrorResponse is exported for type checking if needed
+import { formatError } from "../errorHandler"; // Assuming ErrorResponse is exported for type checking if needed
 
 describe("errorHandler", () => {
   describe("formatError", () => {


### PR DESCRIPTION
I removed the unused `ErrorResponse` import from `src/utils/__tests__/errorHandler.test.ts` to resolve a lint warning (`@typescript-eslint/no-unused-vars`).

This change addresses a minor lint issue and has no impact on runtime behavior. All tests continue to pass.