### PR TITLE
Fix: Address multiple `no-unused-vars` linting warnings

### DIFF
--- a/src/services/__tests__/youtube/getChannelTopVideos.test.ts
+++ b/src/services/__tests__/youtube/getChannelTopVideos.test.ts
@@ -98,7 +98,7 @@ describe("YoutubeService.getChannelTopVideos", () => {
         `${operationName}-${JSON.stringify(options || {})}`
     );
     mockCacheService.getOrSet.mockImplementation(
-      async (key, operation, ttl, collection) => operation()
+      async (key, operation, _ttl, _collection) => operation()
     );
 
     videoManagement = new YoutubeService(mockCacheService); // Pass mockCacheService
@@ -387,7 +387,7 @@ describe("YoutubeService.getChannelTopVideos", () => {
 
     // Assertions for the result
     expect(result).toHaveLength(requestedMaxResults);
-    allVideoIds.forEach((videoId, index) => {
+    allVideoIds.forEach((videoId) => {
       const video = result.find((v) => v.id === videoId);
       expect(video).toBeDefined();
       expect(video).toMatchObject({
@@ -404,13 +404,11 @@ describe("YoutubeService.getChannelTopVideos", () => {
     const MAX_RESULTS_PER_PAGE = 50;
     const ABSOLUTE_MAX_RESULTS = 500; // Defined in VideoManagement class
 
-    let searchCallCount = 0;
     const generateSearchPage = (
       pageNumber: number,
       itemsOnPage: number,
       hasNextPage: boolean
     ) => {
-      searchCallCount++;
       return {
         data: {
           items: Array.from({ length: itemsOnPage }, (_, i) => ({
@@ -757,7 +755,7 @@ describe("YoutubeService.getChannelTopVideos", () => {
 
     expect(result).toHaveLength(mockVideoApiItems.length);
 
-    mockVideoApiItems.forEach((apiItem, index) => {
+    mockVideoApiItems.forEach((apiItem) => {
       const transformedVideo = result.find((v) => v.id === apiItem.id); // Changed v.videoId to v.id
       expect(transformedVideo).toBeDefined();
 

--- a/src/services/__tests__/youtube/getVideo.test.ts
+++ b/src/services/__tests__/youtube/getVideo.test.ts
@@ -18,7 +18,7 @@ jest.mock("../../cache.service", () => {
   return {
     CacheService: jest.fn().mockImplementation(() => {
       return {
-        getOrSet: jest.fn((key, operation, ttl, collection) => operation()),
+        getOrSet: jest.fn((key, operation, _ttl, _collection) => operation()),
         createOperationKey: jest.fn(),
       };
     }),

--- a/src/services/__tests__/youtube/getVideoCategories.test.ts
+++ b/src/services/__tests__/youtube/getVideoCategories.test.ts
@@ -18,7 +18,7 @@ jest.mock("../../cache.service", () => {
   return {
     CacheService: jest.fn().mockImplementation(() => {
       return {
-        getOrSet: jest.fn((key, operation, ttl, collection) => operation()),
+        getOrSet: jest.fn((key, operation, _ttl, _collection) => operation()),
         createOperationKey: jest.fn(),
       };
     }),

--- a/src/services/__tests__/youtube/getVideoComments.test.ts
+++ b/src/services/__tests__/youtube/getVideoComments.test.ts
@@ -1,6 +1,6 @@
 import { YoutubeService } from "../../youtube.service.js";
 import { CacheService } from "../../cache.service.js";
-import { google, youtube_v3 } from "googleapis";
+import { youtube_v3 } from "googleapis";
 import { CACHE_COLLECTIONS, CACHE_TTLS } from "../../../config/cache.config.js";
 
 // Mock the google.youtube object
@@ -25,8 +25,8 @@ describe("YoutubeService - getVideoComments", () => {
 
   beforeEach(() => {
     cacheService = {
-      getOrSet: jest.fn((key, operation, ttl, collection, options, exclude) =>
-        operation()
+      getOrSet: jest.fn(
+        (key, operation, _ttl, _collection, _options, _exclude) => operation()
       ),
       createOperationKey: jest.fn((name, options) =>
         JSON.stringify({ name, options })

--- a/src/services/__tests__/youtube/searchVideos.test.ts
+++ b/src/services/__tests__/youtube/searchVideos.test.ts
@@ -25,7 +25,7 @@ jest.mock("../../cache.service", () => {
           // Simple mock implementation for createOperationKey
           return `${operationName}-${JSON.stringify(options)}`;
         }),
-        getOrSet: jest.fn((key, operation, ttl, collection) => operation()), // Directly run the operation for tests
+        getOrSet: jest.fn((key, operation, _ttl, _collection) => operation()), // Directly run the operation for tests
       };
     }),
   };

--- a/src/services/analysis/__tests__/phase1-candidate-search.test.ts
+++ b/src/services/analysis/__tests__/phase1-candidate-search.test.ts
@@ -1,5 +1,4 @@
 import { executeInitialCandidateSearch } from "../phase1-candidate-search";
-import { CacheService } from "../../cache.service";
 import { YoutubeService } from "../../../services/youtube.service";
 import { FindConsistentOutlierChannelsOptions } from "../../../types/analyzer.types";
 import { youtube_v3 } from "googleapis";

--- a/src/services/analysis/__tests__/phase2-channel-filtering.test.ts
+++ b/src/services/analysis/__tests__/phase2-channel-filtering.test.ts
@@ -1,5 +1,4 @@
 import { executeChannelPreFiltering } from "../phase2-channel-filtering";
-import { CacheService } from "../../cache.service";
 import { YoutubeService } from "../../../services/youtube.service";
 import { NicheRepository } from "../niche.repository"; // Import NicheRepository
 import { FindConsistentOutlierChannelsOptions } from "../../../types/analyzer.types";
@@ -34,13 +33,11 @@ jest.mock("../../../services/youtube.service", () => ({
 // --- End Mock Setup ---
 
 describe("executeChannelPreFiltering", () => {
-  let cacheService: CacheService;
   let youtubeService: YoutubeService;
   let nicheRepository: NicheRepository;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    cacheService = new CacheService({} as any);
     youtubeService = new YoutubeService({} as any);
     nicheRepository = new NicheRepository({} as any);
   });

--- a/src/services/analysis/__tests__/phase3-deep-analysis.test.ts
+++ b/src/services/analysis/__tests__/phase3-deep-analysis.test.ts
@@ -116,7 +116,7 @@ jest.mock("../../cache.service", () => {
           operation: () => Promise<unknown>,
           ttl: number,
           collection: string,
-          params?: object
+          _params?: object
         ) => {
           // Simulate a cache hit using mockDb
           const cachedResult = await mockDb
@@ -186,10 +186,6 @@ jest.mock("../../youtube.service.ts", () => {
     }),
   };
 });
-const MockedVideoManagementService = VideoManagementService as jest.MockedClass<
-  typeof VideoManagementService
->;
-
 // Mock analysis.logic functions
 jest.mock("../analysis.logic");
 const mockedAnalysisLogic = analysisLogic as jest.Mocked<typeof analysisLogic>;
@@ -222,9 +218,7 @@ describe("executeDeepConsistencyAnalysis Function", () => {
     // Since YoutubeService is fully mocked, cacheServiceInstance is not strictly needed here for the test itself.
     // However, keeping it for consistency with the mock setup of YoutubeService.
     cacheServiceInstance = new MockedCacheService();
-    videoManagementInstance = new MockedVideoManagementService(
-      cacheServiceInstance
-    ) as jest.Mocked<VideoManagementService>; // YoutubeService now takes CacheService
+    videoManagementInstance = new VideoManagementService(cacheServiceInstance); // YoutubeService now takes CacheService
     nicheRepositoryInstance = new MockedNicheRepository();
 
     // Initialize variables for each test

--- a/src/services/analysis/__tests__/phase4-ranking-formatting.test.ts
+++ b/src/services/analysis/__tests__/phase4-ranking-formatting.test.ts
@@ -8,15 +8,6 @@ import {
 describe("Phase 4 Ranking and Formatting", () => {
   const commonLatestAnalysisMetricsStandard = {};
 
-  const commonLatestAnalysisOptions = {
-    outlierMagnitude: "STANDARD" as const, // Ensure this is treated as a literal type
-    viewsLookbackWindow: 30,
-    minimumTotalViews: 1000,
-    minimumSubscribers: 100,
-    consistencyThreshold: 0.5,
-    checkFrequencyDays: 7,
-  };
-
   const commonLatestStats = {
     viewCount: 100000,
     lastUploadDate: new Date(),
@@ -105,12 +96,6 @@ describe("Phase 4 Ranking and Formatting", () => {
     };
 
     const result = formatAndRankAnalysisResults(mockChannels, options, false);
-
-    // Manually calculate confidence scores
-    // Score = consistencyPercentage * Math.log10(outlierCount + 1) * (subscriberCount / videoCount)
-    const scoreChannel1 = 0.8 * Math.log10(10 + 1) * (1000 / 100); // 0.8 * log10(11) * 10 = 0.8 * 1.04139 * 10 = 8.3311
-    const scoreChannel2 = 0.9 * Math.log10(15 + 1) * (2000 / 50); // 0.9 * log10(16) * 40 = 0.9 * 1.20412 * 40 = 43.34832
-    const scoreChannel3 = 0.7 * Math.log10(5 + 1) * (500 / 200); // 0.7 * log10(6) * 2.5 = 0.7 * 0.77815 * 2.5 = 1.36176
 
     // Expected order: channel2, channel1, channel3
     expect(result.results.length).toBe(3);

--- a/src/services/cache.service.ts
+++ b/src/services/cache.service.ts
@@ -1,4 +1,4 @@
-import { Db, Collection } from "mongodb";
+import { Collection } from "mongodb";
 import { createHash } from "crypto";
 import { omitPaths } from "../utils/objectUtils.js";
 import { getDb } from "./database.service.js"; // Import the lazy loader

--- a/src/services/transcript.service.ts
+++ b/src/services/transcript.service.ts
@@ -47,7 +47,7 @@ export class TranscriptService {
           lang: lang,
         });
         return transcript;
-      } catch (error) {
+      } catch (_error) {
         return [];
       }
     };

--- a/src/tools/general/__tests__/findConsistentOutlierChannels.test.ts
+++ b/src/tools/general/__tests__/findConsistentOutlierChannels.test.ts
@@ -43,12 +43,6 @@ describe("findConsistentOutlierChannelsHandler", () => {
       // ... other valid parameters based on findConsistentOutlierChannelsSchema ...
       maxResults: 10,
     };
-    const mockResponse = {
-      // This is not how the handler is structured.
-      // The handler returns CallToolResult, not uses res.status.json
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-    } as any; // This needs to be changed based on actual handler return type.
 
     const mockOutlierChannels = [{ channelId: "UC-test-channel" }];
     (

--- a/src/tools/general/__tests__/getVideoCategories.test.ts
+++ b/src/tools/general/__tests__/getVideoCategories.test.ts
@@ -1,7 +1,6 @@
 import { getVideoCategoriesHandler } from "../getVideoCategories";
 // import { youtube } from '@googleapis/youtube'; // Removed
 import { YoutubeService } from "../../../services/youtube.service";
-import { google } from "googleapis"; // To set up the mock structure
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types";
 
 jest.mock("googleapis", () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -40,7 +40,6 @@ import {
   findConsistentOutlierChannelsConfig,
   findConsistentOutlierChannelsHandler,
 } from "./general/findConsistentOutlierChannels.js";
-import { isEnabled } from "../utils/featureFlags.js";
 
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { IServiceContainer } from "../container.js";
@@ -53,17 +52,16 @@ import type {
   TrendingParams,
   VideoCategoriesParams,
   FindConsistentOutlierChannelsParams,
-  GetVideoCommentsParams,
 } from "../types/tools.js";
-import { z } from "zod";
+import { z, AnyZodObject } from "zod";
 
-export interface ToolDefinition<TParams = unknown> {
+export interface ToolDefinition {
   config: {
     name: string;
     description: string;
-    inputSchema: z.ZodObject<any>;
+    inputSchema: AnyZodObject;
   };
-  handler: (params: TParams) => Promise<CallToolResult>;
+  handler: (params: any) => Promise<CallToolResult>;
 }
 
 export function allTools(container: IServiceContainer): ToolDefinition[] {
@@ -71,7 +69,7 @@ export function allTools(container: IServiceContainer): ToolDefinition[] {
   const { youtubeService, transcriptService } = container;
 
   // 2. Define all tools, wrapping the original handlers with the dependencies they need.
-  const toolDefinitions: ToolDefinition<any>[] = [
+  const toolDefinitions: ToolDefinition[] = [
     // Video tools
     {
       config: getVideoDetailsConfig,


### PR DESCRIPTION
This commit resolves a significant number of `@typescript-eslint/no-unused-vars` warnings across the codebase.

The following changes were made:
- Removed unused imports in test files and source files.
- Prefixed unused function arguments with an underscore (`_`) to indicate they are intentionally unused.
- Removed unused local variables within functions and tests.
- Removed an unnecessary type assertion that was causing a linting warning.

These changes improve code cleanliness and maintainability without altering any application logic. All tests and formatting checks pass.